### PR TITLE
CYB-395 - Removed unused dc-visuallyhidden class

### DIFF
--- a/app/assets/javascripts/angular/directives/outboundLinkDirective.js
+++ b/app/assets/javascripts/angular/directives/outboundLinkDirective.js
@@ -42,16 +42,17 @@
   };
 
   /**
-   * This directive will make sure that external links are always opened in a new window
-   * To make it more accessible, we also add an extra message to each element.
+   * Ensure that external links are always opened in a new window. To improve accessibility,
+   * a screenreader message is added to each external link
    */
   angular.module('datacultures.directives').directive('a', function() {
     return {
       restrict: 'E',
       priority: 200, // We need to run this after ngHref has changed
       link: function(scope, element, attr) {
+
         /**
-         * We update the anchor tag
+         * When the current URL is an external
          * @param {String} url The URL of the anchor tag.
          */
         var updateAnchorTag = function(url) {
@@ -59,10 +60,12 @@
           // Since this gets executed a couple of times, we add a class to the screenreader message & check for it
           if (!isSameDomain(url, location.href) && !element[0].querySelector('.dc-outbound-link')) {
             var screenReadMessage = document.createElement('span');
-            screenReadMessage.className = 'dc-outbound-link dc-visuallyhidden';
-            screenReadMessage.innerHTML = ' - opens in new window';
+            // Ensure that the screenreader message is only visible to screenreaders
+            screenReadMessage.className = 'sr-only';
+            screenReadMessage.innerHTML = '(opens in new window)';
             element.append(screenReadMessage);
             element.addClass('dc-outbound-link');
+            // Ensure that the link is opened in a new window
             attr.$set('target', '_blank');
           }
         };

--- a/app/assets/javascripts/angular/directives/outboundLinkDirective.js
+++ b/app/assets/javascripts/angular/directives/outboundLinkDirective.js
@@ -9,7 +9,7 @@
    * @return {Boolean}                    Whether the provided URL is external
    * @api private
    */
-  var isExternalURL = function (url) {
+  var isExternalURL = function(url) {
     // Relative URLs are never external
     if (url[0] === '/') {
       return false;

--- a/app/assets/javascripts/angular/directives/outboundLinkDirective.js
+++ b/app/assets/javascripts/angular/directives/outboundLinkDirective.js
@@ -2,43 +2,29 @@
   'use strict';
 
   /**
-   * Parse a request and location URL and determine whether this is a same-domain request.
-   * This function has been copied over from AngularJS since they don't expose this function
+   * Check whether a URL is an external URL
+   * @see http://stackoverflow.com/questions/6238351/fastest-way-to-detect-external-urls
    *
-   * @param {string} requestUrl The url of the request.
-   * @param {string} locationUrl The current browser location url.
-   * @returns {boolean} Whether the request is for the same domain.
+   * @param  {String}       url           The URL to check for being an external URL
+   * @return {Boolean}                    Whether the provided URL is external
+   * @api private
    */
-  var isSameDomain = function(requestUrl, locationUrl) {
-    var DEFAULT_PORTS = {'http': 80, 'https': 443, 'ftp': 21};
-    var IS_SAME_DOMAIN_URL_MATCH = /^(([^:]+):)?\/\/(\w+:{0,1}\w*@)?([\w\.-]*)?(:([0-9]+))?(.*)$/;
-    var URL_MATCH = /^([^:]+):\/\/(\w+:{0,1}\w*@)?([\w\.-]*)(:([0-9]+))?(\/[^\?#]*)?(\?([^#]*))?(#(.*))?$/;
-
-    var match = IS_SAME_DOMAIN_URL_MATCH.exec(requestUrl);
-    // if requestUrl is relative, the regex does not match.
-    if (match === null) {
-      return true;
+  var isExternalURL = function (url) {
+    // Relative URLs are never external
+    if (url[0] === '/') {
+      return false;
     }
+    return extractDomain(location.href) !== extractDomain(url);
+  };
 
-    var domain1 = {
-      protocol: match[2],
-      host: match[4],
-      port: parseInt(match[6], 10) || DEFAULT_PORTS[match[2]] || null,
-      // IE8 sets unmatched groups to '' instead of undefined.
-      relativeProtocol: match[2] === undefined || match[2] === ''
-    };
-
-    match = URL_MATCH.exec(locationUrl);
-    var domain2 = {
-      protocol: match[1],
-      host: match[3],
-      port: parseInt(match[5], 10) || DEFAULT_PORTS[match[1]] || null
-    };
-
-    return (domain1.protocol === domain2.protocol || domain1.relativeProtocol) &&
-           domain1.host === domain2.host &&
-           (domain1.port === domain2.port || (domain1.relativeProtocol &&
-               domain2.port === DEFAULT_PORTS[domain2.protocol]));
+  /**
+   * Extract the domain from a URL
+   *
+   * @param  {String}       url         The URL to extract the domain from
+   * @api private
+   */
+  var extractDomain = function(url) {
+    return url.replace('http://','').replace('https://','').split('/')[0];
   };
 
   /**
@@ -48,17 +34,20 @@
   angular.module('datacultures.directives').directive('a', function() {
     return {
       restrict: 'E',
-      priority: 200, // We need to run this after ngHref has changed
+      priority: 200, // This needs to run after ngHref has changed
       link: function(scope, element, attr) {
 
         /**
-         * We update the anchor tag
-         * @param {String} url The URL of the anchor tag.
+         * For external links, ensure that the link is always opened in a new window
+         * and add a screenreader message
+         *
+         * @param  {String}       url         The URL to to process
+         * @api private
          */
         var updateAnchorTag = function(url) {
-          // We only want to change anchor tags that link to a different domain
-          // Since this gets executed a couple of times, we add a class to the screenreader message & check for it
-          if (!isSameDomain(url, location.href) && !element[0].querySelector('.dc-outbound-link')) {
+          // Only process external URLs. To prevent anchors from being processed multiple times,
+          // a `dc-outbound-link` class is added to processed anchors
+          if (url && isExternalURL(url) && !element[0].querySelector('.dc-outbound-link')) {
             var screenReadMessage = document.createElement('span');
             // Ensure that the screenreader message is only visible to screenreaders
             screenReadMessage.className = 'sr-only';
@@ -70,17 +59,7 @@
           }
         };
 
-        /**
-         * Check whether the href attribute has changed
-         */
-        var observe = function(value) {
-          // Check whether the element actually has an href
-          if (value) {
-            updateAnchorTag(value);
-          }
-        };
-
-        attr.$observe('href', observe);
+        attr.$observe('href', updateAnchorTag);
       }
     };
   });

--- a/app/assets/javascripts/angular/directives/outboundLinkDirective.js
+++ b/app/assets/javascripts/angular/directives/outboundLinkDirective.js
@@ -10,8 +10,9 @@
    * @api private
    */
   var isExternalURL = function(url) {
-    // Relative URLs are never external
-    if (url[0] === '/') {
+    // Relative URLs are never external. However, we ensure that the second character
+    // is not a `/` to account for protocol relative URLs (e.g. `//www.google.com`)
+    if (url[0] === '/' && url[1] !== '/') {
       return false;
     }
     return extractDomain(location.href) !== extractDomain(url);

--- a/app/assets/javascripts/angular/directives/outboundLinkDirective.js
+++ b/app/assets/javascripts/angular/directives/outboundLinkDirective.js
@@ -52,7 +52,7 @@
       link: function(scope, element, attr) {
 
         /**
-         * When the current URL is an external
+         * We update the anchor tag
          * @param {String} url The URL of the anchor tag.
          */
         var updateAnchorTag = function(url) {

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -86,15 +86,3 @@ label {
 .dc-page-error-text {
   font-size: 16px;
 }
-
-// Hidden
-.dc-visuallyhidden {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-}


### PR DESCRIPTION
I couldn't find any instances of where this was being used. As far as I can tell, the only instance where we have outbound links is the 'Open website' link for generic URLs, which already has the appropriate `target="_blank" ` attribute.

https://jira.ets.berkeley.edu/jira/browse/CYB-395