### PR TITLE
CYB-400 - Remove jQuery and use Highcharts standalone

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ gem 'font-awesome-rails',      '~> 4.2.0.0'
 # JavaScript
 gem 'coffee-rails',            '~> 4.0'
 gem 'angular-gem',             '~> 1.3.7'
-gem 'jquery-rails',            '~> 3.1.2'
 
 # https://rubygems.org/gems/ngannotate-rails
 gem 'ngannotate-rails',        '~> 0.14.1'

--- a/app/assets/javascripts/angular/controllers/engagementIndexController.js
+++ b/app/assets/javascripts/angular/controllers/engagementIndexController.js
@@ -1,4 +1,4 @@
-(function(angular) {
+(function(angular, Highcharts) {
   'use strict';
 
   angular.module('datacultures.controllers').controller('EngagementIndexController', function(engagementIndexFactory, userService, utilService, $scope) {
@@ -62,7 +62,7 @@
       setTimeout(function() {
         // Render the box plot using highcharts
         // @see http://api.highcharts.com/highcharts
-        var chart = new Highcharts.Chart({
+        new Highcharts.Chart({
           chart: {
             backgroundColor: 'transparent',
             inverted: true,
@@ -274,4 +274,4 @@
 
   });
 
-})(window.angular);
+})(window.angular, window.Highcharts);

--- a/app/assets/javascripts/angular/controllers/engagementIndexController.js
+++ b/app/assets/javascripts/angular/controllers/engagementIndexController.js
@@ -7,6 +7,9 @@
     $scope.sortBy = 'rank';
     $scope.reverse = true;
 
+    // Variable that will be used to hold the box plot
+    var chart = null;
+
     /**
      * Get the students in the engagement index and their engagement
      * index points
@@ -62,7 +65,7 @@
       setTimeout(function() {
         // Render the box plot using highcharts
         // @see http://api.highcharts.com/highcharts
-        new Highcharts.Chart({
+        chart = new Highcharts.Chart({
           chart: {
             backgroundColor: 'transparent',
             inverted: true,

--- a/app/assets/javascripts/angular/controllers/engagementIndexController.js
+++ b/app/assets/javascripts/angular/controllers/engagementIndexController.js
@@ -1,4 +1,4 @@
-(function(angular, $) {
+(function(angular) {
   'use strict';
 
   angular.module('datacultures.controllers').controller('EngagementIndexController', function(engagementIndexFactory, userService, utilService, $scope) {
@@ -62,12 +62,13 @@
       setTimeout(function() {
         // Render the box plot using highcharts
         // @see http://api.highcharts.com/highcharts
-        $('#dc-user-badge-boxplot').highcharts({
+        var chart = new Highcharts.Chart({
           chart: {
             backgroundColor: 'transparent',
             inverted: true,
             // Ensure that the box plot is displayed horizontally
             margin: [0, 20, 0, 20],
+            renderTo: 'dc-user-badge-boxplot',
             type: 'boxplot'
           },
 
@@ -273,4 +274,4 @@
 
   });
 
-})(window.angular, window.jQuery);
+})(window.angular);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,7 @@
 //= require angular-route
 //= require angular-sanitize
 //= require angular-rails-templates
-//= require jquery
+//= require highcharts/adapters/standalone-framework
 //= require highcharts
 //= require highcharts/highcharts-more
 //= require_tree ../templates


### PR DESCRIPTION
This PR switches to Highcharts standalone and removes jQuery again from the project. The issue I was experiencing with Highcharts standalone and Angular turned out to be a dependency ordering issue.

Given that this will be rolled out to production soon, it does make sense to keep jQuery out of this as we're not using it for anything else. Note that in the Collabosphere project, I will probably be bringing in jQuery to use it for the things that I don't think we should be using plain Javascript for (e.g. determining the height of the current window, certain types of event binding, etc.)