### PR TITLE
CYB-420 - Gallery: Chrome maintains scroll position between gallery and detail view

### DIFF
--- a/app/assets/javascripts/angular/services/utilService.js
+++ b/app/assets/javascripts/angular/services/utilService.js
@@ -11,7 +11,7 @@
      */
     var resizeIFrame = function() {
       postIFrameMessage(function() {
-        var height = document.body.scrollHeight;
+        var height = document.body.offsetHeight;
         return {
           subject: 'changeParent',
           height: height


### PR DESCRIPTION
As there is no margin on the body of the window, we should be using `offsetHeight`

https://jira.ets.berkeley.edu/jira/browse/CYB-420