### PR TITLE
CYB-421 - Engagement index: points not updated correctly when a vote is reversed

### DIFF
--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -11,13 +11,20 @@ class Api::V1::LikesController < ApplicationController
   def create
     original_poster = posting_user_id
     if (original_poster.to_s != current_user.canvas_id.to_s)
-      previous_records(user_list: [original_poster, current_user.canvas_id]).each do |previous_record|
+      # Invalidate the existing like/dislike record
+      previous_records(user: current_user.canvas_id).each do |previous_record|
+        previous_record.retire!
+      end
+      # Invalidate the existing get a like/get a dislike record
+      previous_actor_records(user: current_user.canvas_id).each do |previous_record|
         previous_record.retire!
       end
       if [true, false].include?(safe_params['liked'])
         Activity.score!(values_for_create(canvas_user_id: current_user.canvas_id,
+                                          canvas_user_actor_id: nil,
                                           activity_name: like_type(user_type: 'CurrentUser')))
         Activity.score!(values_for_create(canvas_user_id: original_poster,
+                                          canvas_user_actor_id: current_user.canvas_id,
                                           activity_name: like_type(user_type: 'OriginalPoster')))
       end
       head :created
@@ -32,9 +39,10 @@ class Api::V1::LikesController < ApplicationController
       params.permit(:liked, :id)
     end
 
-    def values_for_create(canvas_user_id:, activity_name:)
+    def values_for_create(canvas_user_id:, canvas_user_actor_id:, activity_name:)
       {
           canvas_user_id: canvas_user_id,
+          canvas_user_actor_id: canvas_user_actor_id,
           reason: activity_name,
           scoring_item_id: safe_params['id'],
           canvas_updated_at: Time.now,
@@ -52,10 +60,16 @@ class Api::V1::LikesController < ApplicationController
       safe_params[:id].gallery_model_class.where(gallery_id: safe_params[:id]).first.try(:canvas_user_id)
     end
 
-    def previous_records(user_list:)
+    def previous_records(user:)
       Activity.current.where(reason: ['Like', 'Dislike'],
                      scoring_item_id: safe_params['id'],
-                     canvas_user_id: user_list)
+                     canvas_user_id: user)
+    end
+
+    def previous_actor_records(user:)
+      Activity.current.where(reason: ['GetALike', 'GetADislike'],
+                     scoring_item_id: safe_params['id'],
+                     canvas_user_actor_id: user)
     end
 
 end

--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -11,11 +11,11 @@ class Api::V1::LikesController < ApplicationController
   def create
     original_poster = posting_user_id
     if (original_poster.to_s != current_user.canvas_id.to_s)
-      # Invalidate the existing like/dislike record
+      # Invalidate the existing like/dislike record(s)
       previous_records(user: current_user.canvas_id).each do |previous_record|
         previous_record.retire!
       end
-      # Invalidate the existing get a like/get a dislike record
+      # Invalidate the existing get a like/get a dislike record(s)
       previous_actor_records(user: current_user.canvas_id).each do |previous_record|
         previous_record.retire!
       end

--- a/db/migrate/20150115105930105930_add_canvas_student_actor_id_field_to_activities.rb
+++ b/db/migrate/20150115105930105930_add_canvas_student_actor_id_field_to_activities.rb
@@ -1,0 +1,5 @@
+class AddCanvasStudentActorIdFieldToActivities < ActiveRecord::Migration
+  def change
+    add_column :activities, :canvas_user_actor_id, :integer
+  end
+end


### PR DESCRIPTION
Store the original actor when a GetALike or GetADislike activity is recorded.

https://jira.ets.berkeley.edu/jira/browse/CYB-421