### PR TITLE
Use Travis their container based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 bundler_args: --without production --jobs=4 --retry=5
+language: ruby
+sudo: false
 
 rvm:
   - "2.1.1"


### PR DESCRIPTION
This should result in reduced build times. Travis will be able to provision
a container much quicker as it’s easier to spin up a new container and they
usually provision more capacity for containers.

For more information, check out http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

I also added in the ruby language just to pass Travis their lint validation